### PR TITLE
Replace Nothing with Missing for unknown stability

### DIFF
--- a/src/algorithms/davidchack_lai.jl
+++ b/src/algorithms/davidchack_lai.jl
@@ -184,7 +184,7 @@ function convert_to_pos(ds, fps, T)
     count = 1
     for t in 1:T+1
         for pp in fps[t]
-            po[count] = PeriodicOrbit(ds, pp, t, nothing)
+            po[count] = PeriodicOrbit(ds, pp, t, missing)
             count += 1
         end
     end

--- a/src/api.jl
+++ b/src/api.jl
@@ -32,19 +32,19 @@ A structure that contains information about a periodic orbit.
 * `points::StateSpaceSet` - points of the periodic orbit. This container 
   always holds the complete orbit.
 * `T::Real` - the period of the orbit
-* `stable::Union{Bool, Nothing}` - local stability of the periodic orbit. Unknown stability 
-  is set to `nothing`.
+* `stable::Union{Bool, Missing}` - local stability of the periodic orbit. Unknown stability 
+  is set to `missing`.
 
 """
 struct PeriodicOrbit{D, B, R<:Real}
     points::StateSpaceSet{D, B}
     T::R
-    stable::Union{Bool, Nothing}
+    stable::Union{Bool, Missing}
 end
 
 """
     PeriodicOrbit(ds::ContinuousTimeDynamicalSystem, u0::AbstractArray{<:Real},
-        T::AbstractFloat, Δt=T/$(default_Δt_partition), stable=nothing) → po
+        T::AbstractFloat, Δt=T/$(default_Δt_partition), stable=missing) → po
 
 Given a point `u0` on the periodic orbit of the dynamical system `ds` and the period `T` 
 of the orbit, the remaining points of the orbit are computed and stored in the `points` 
@@ -53,20 +53,20 @@ field of the returned `po::PeriodicOrbit`. The orbit which contains infinitely m
  `po.points`. 
 """
 function PeriodicOrbit(ds::ContinuousTimeDynamicalSystem, u0::AbstractArray{<:Real}, 
-    T::AbstractFloat, Δt=T/default_Δt_partition, stable::Union{Bool, Nothing}=nothing)
+    T::AbstractFloat, Δt=T/default_Δt_partition, stable::Union{Bool, Missing}=missing)
     return PeriodicOrbit(complete_orbit(ds, u0, T; Δt=Δt), T, stable)
 end
 
 """
     PeriodicOrbit(ds::DiscreteTimeDynamicalSystem, u0::AbstractArray{<:Real}, 
-        T::Integer, stable=nothing) → po
+        T::Integer, stable=missing) → po
 
 Given a point `u0` on the periodic orbit of the dynamical system `ds` and the period `T` 
 of the orbit, the remaining points of the orbit are computed and stored in the `points` 
 field of the returned `po::PeriodicOrbit`. The orbit is obtained by iterating the periodic 
 point `T-1` times and the points are stored in `po.points`.
 """
-function PeriodicOrbit(ds::DiscreteTimeDynamicalSystem, u0::AbstractArray{<:Real}, T::Integer, stable::Union{Bool, Nothing}=nothing)
+function PeriodicOrbit(ds::DiscreteTimeDynamicalSystem, u0::AbstractArray{<:Real}, T::Integer, stable::Union{Bool, Missing}=missing)
     discrete_timestep = 1
     return PeriodicOrbit(complete_orbit(ds, u0, T; Δt=discrete_timestep), T, stable)
 end

--- a/test/minimal_period.jl
+++ b/test/minimal_period.jl
@@ -32,7 +32,7 @@ end
     po = PeriodicOrbit(ds, u0, n*T, 0.01)
     minT_po = minimal_period(ds, po)
     @test length(minT_po.points) == minT_po.T / (minT_po.T / PeriodicOrbits.default_Δt_partition)
-    @test po.stable == minT_po.stable
+    @test (ismissing(po.stable) && ismissing(minT_po.stable)) || (po.stable == minT_po.stable) 
     @test isapprox(T, minT_po.T; atol=1e-4)
 end
 


### PR DESCRIPTION
Unknown local stability is set to `missing` instead of `nothing` as mentioned in issue #22.